### PR TITLE
add support for Lenovo Tab M10 HD

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Supported devices:
 
 - Redmi 7 (xiaomi-onclite).
 - Redmi 7A (xioami-pine)
+- Lenovo Tab M10 HD (lenovo-tbx505x)
 
 Used for lk2nd and mainline kernel.
 

--- a/build.sh
+++ b/build.sh
@@ -5,3 +5,5 @@ dtc -O dtb -o sdm632-xiaomi-onclite.dtbo -b 0 -@ sdm632-xiaomi-onclite.dts
 mkdtboimg cfg_create dtbo-xiaomi-onclite.img dtboimg-xiaomi-onclite.cfg
 dtc -O dtb -o sdm439-xiaomi-pine.dtbo -b 0 -@ sdm439-xiaomi-pine.dts
 mkdtboimg cfg_create dtbo-xiaomi-pine.img dtboimg-xiaomi-pine.cfg
+dtc -O dtb -o sdm429-lenovo-tbx505x.dtbo -b 0 -@ sdm429-lenovo-tbx505x.dts
+mkdtboimg cfg_create dtbo-lenovo-tbx505x.img dtboimg-lenovo-tbx505x.cfg

--- a/dtboimg-lenovo-tbx505x.cfg
+++ b/dtboimg-lenovo-tbx505x.cfg
@@ -1,0 +1,3 @@
+sdm429-lenovo-tbx505x.dtbo
+	id=0x0
+	rev=0x0

--- a/sdm429-lenovo-tbx505x.dts
+++ b/sdm429-lenovo-tbx505x.dts
@@ -1,0 +1,7 @@
+/dts-v1/;
+
+/ {
+	qcom,board-id = <0x8 2>;
+
+	__fixups__ {};
+};


### PR DESCRIPTION
Add support for Lenovo Tab M10 HD (TB-X505X), a tablet form-factor device with Qualcomm's Snapdragon 429 (SDM429) chipset.