### PR TITLE
add support for Fossil Gen 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Supported devices:
 - Redmi 7 (xiaomi-onclite).
 - Redmi 7A (xioami-pine)
 - Lenovo Tab M10 HD (lenovo-tbx505x)
+- Fossil Gen 6 (fossil-hoki)
 
 Used for lk2nd and mainline kernel.
 

--- a/build.sh
+++ b/build.sh
@@ -7,3 +7,5 @@ dtc -O dtb -o sdm439-xiaomi-pine.dtbo -b 0 -@ sdm439-xiaomi-pine.dts
 mkdtboimg cfg_create dtbo-xiaomi-pine.img dtboimg-xiaomi-pine.cfg
 dtc -O dtb -o sdm429-lenovo-tbx505x.dtbo -b 0 -@ sdm429-lenovo-tbx505x.dts
 mkdtboimg cfg_create dtbo-lenovo-tbx505x.img dtboimg-lenovo-tbx505x.cfg
+dtc -O dtb -o sdm429-fossil-hoki.dtbo -b 0 -@ sdm429-fossil-hoki.dts
+mkdtboimg cfg_create dtbo-fossil-hoki.img dtboimg-fossil-hoki.cfg

--- a/dtboimg-fossil-hoki.cfg
+++ b/dtboimg-fossil-hoki.cfg
@@ -1,0 +1,3 @@
+sdm429-fossil-hoki.dtbo
+	id=0x0
+	rev=0x0

--- a/sdm429-fossil-hoki.dts
+++ b/sdm429-fossil-hoki.dts
@@ -1,0 +1,7 @@
+/dts-v1/;
+
+/ {
+	qcom,board-id = <0x10b 0x0a>;
+
+	__fixups__ {};
+};


### PR DESCRIPTION
Add support for Fossil Gen 6 (fossil-hoki), a smartwatch with sdm429w chipset.