### PR TITLE
add support for Xiaomi Redmi 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Supported devices:
 
 - Redmi 7 (xiaomi-onclite).
 - Redmi 7A (xiaomi-pine)
+- Redmi 8 (xiaomi-olive)
 - Lenovo Tab M10 HD (lenovo-tbx505x)
 - Fossil Gen 6 (fossil-hoki)
 - HMD Global Nokia 4.2 (nokia-panther)

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,8 @@ dtc -O dtb -o sdm632-xiaomi-onclite.dtbo -b 0 -@ sdm632-xiaomi-onclite.dts
 mkdtboimg cfg_create dtbo-xiaomi-onclite.img dtboimg-xiaomi-onclite.cfg
 dtc -O dtb -o sdm439-xiaomi-pine.dtbo -b 0 -@ sdm439-xiaomi-pine.dts
 mkdtboimg cfg_create dtbo-xiaomi-pine.img dtboimg-xiaomi-pine.cfg
+dtc -O dtb -o sdm439-xiaomi-olive.dtbo -b 0 -@ sdm439-xiaomi-olive.dts
+mkdtboimg cfg_create dtbo-xiaomi-olive.img dtboimg-xiaomi-olive.cfg
 dtc -O dtb -o sdm429-lenovo-tbx505x.dtbo -b 0 -@ sdm429-lenovo-tbx505x.dts
 mkdtboimg cfg_create dtbo-lenovo-tbx505x.img dtboimg-lenovo-tbx505x.cfg
 dtc -O dtb -o sdm429-fossil-hoki.dtbo -b 0 -@ sdm429-fossil-hoki.dts

--- a/dtboimg-xiaomi-olive.cfg
+++ b/dtboimg-xiaomi-olive.cfg
@@ -1,0 +1,3 @@
+sdm439-xiaomi-olive.dtbo
+	id=0x0
+	rev=0x0

--- a/sdm439-xiaomi-olive.dts
+++ b/sdm439-xiaomi-olive.dts
@@ -1,0 +1,7 @@
+/dts-v1/;
+
+/ {
+	qcom,board-id = <0xb 0x8>;
+
+	__fixups__ {};
+};


### PR DESCRIPTION
Add support for Xiaomi Redmi 8 (xiaomi-olive), a smartphone with SDM439 chipset.