### PR TITLE
Add Samsung Galaxy Tab A7 10.4 2020 (samsung-gta4l)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Supported devices:
 - Motorola Moto G7 Power (motorola-ocean)
 - Motorola Moto G7 Play (motorola-channel)
 - Oppo Realme 2/C1 (oppo-rmx1805)
+- Samsung Galaxy Tab A7 10.4 2020 (samsung-gta4l)
 
 Used for lk2nd and mainline kernel.
 

--- a/dtboimg-samsung-gta4l.cfg
+++ b/dtboimg-samsung-gta4l.cfg
@@ -1,0 +1,3 @@
+sm6115-samsung-gta4l.dtbo
+	id=0x0
+	rev=0x0

--- a/sm6115-samsung-gta4l.dts
+++ b/sm6115-samsung-gta4l.dts
@@ -1,0 +1,8 @@
+/dts-v1/;
+
+/ {
+	qcom,board-id = <0x1000b 0x00>;
+
+	__fixups__ {};
+
+};


### PR DESCRIPTION
There is no lk2nd support for this device or SoC; however, a minimal DTBO is still required to boot mainline.